### PR TITLE
Add scopes for hooks

### DIFF
--- a/test/robert/test_hooke.clj
+++ b/test/robert/test_hooke.clj
@@ -83,3 +83,10 @@
   (is (= (keyed 1) 4))
   (clear-hooks #'keyed)
   (is (= (keyed 1) 1)))
+
+(deftest hook-scope-test
+  (is (hooked))
+  (hook-scope
+   (add-hook #'hooked asplode)
+   (is (thrown? Exception (hooked))))
+  (is (hooked)))


### PR DESCRIPTION
Adds a hook-scope macro that provides a scope which records any change to
hooks during the dynamic scope of its body, and restores hooks to their
original state on exit of the scope.

This has only been lightly tested, as I wanted to get feedback as to whether this was a welcome addition or not. The motivation for this is to allow lein sub to apply plugins properly to sub-projects, without having their hooks spill over between projects.
