### PR TITLE
Added "with-hooks-disabled-1" macro

### DIFF
--- a/src/robert/hooke.clj
+++ b/src/robert/hooke.clj
@@ -131,8 +131,12 @@ of its body, and restores hooks to their original state on exit of the scope."
                                    ~@body
                                    val#))))
 
+(defmacro with-hooks-disabled-1 [f & body]
+  `(with-redefs [~f (or (#'original (var ~f)) ~f)]
+         ~@body))
+
 (defmacro with-hooks-disabled [f & body]
   `(do (when-not (#'hooks (var ~f))
          (throw (Exception. (str "No hooks on " ~f))))
-       (with-redefs [~f (#'original (var ~f))]
-         ~@body)))
+       (with-hooks-disabled-1 ~f ~@body)))
+

--- a/test/robert/test_hooke.clj
+++ b/test/robert/test_hooke.clj
@@ -66,6 +66,9 @@
   true)
 
 (deftest test-without-hooks
+  (is (thrown? Exception (with-hooks-disabled another-fn)))
+  (with-hooks-disabled-1 another-fn
+    (is (another-fn)))
   (add-hook #'another-fn asplode)
   (is (thrown? Exception (another-fn)))
   (with-hooks-disabled another-fn


### PR DESCRIPTION
Added "with-hooks-disabled-1" macro that doesn't throw an exception when there is no hooks with function.
Fixed issue 12.

https://github.com/technomancy/robert-hooke/issues/12
