### PR TITLE
with-hooks-disabled thread visibility and f meta

### DIFF
--- a/src/robert/hooke.clj
+++ b/src/robert/hooke.clj
@@ -134,5 +134,5 @@ of its body, and restores hooks to their original state on exit of the scope."
 (defmacro with-hooks-disabled [f & body]
   `(do (when-not (#'hooks (var ~f))
          (throw (Exception. (str "No hooks on " ~f))))
-       (with-redefs [~f (#'original (var ~f))]
+       (with-bindings {(var ~f) (#'original (var ~f))}
          ~@body)))

--- a/test/robert/test_hooke.clj
+++ b/test/robert/test_hooke.clj
@@ -68,8 +68,7 @@
   (is (= :hello (ohai)))
   (is @appended))
 
-(defn another-fn []
-  true)
+(defn ^:dynamic another-fn [] true)
 
 (deftest test-without-hooks
   (add-hook #'another-fn asplode)


### PR DESCRIPTION
Current implementation of with-hooks-disabled makes use of with-redefs that are visible to all running threads, 

This makes its use in multi threaded code unexpected (some threads will have it disabled while other don't depends on with-redefs call duration).

Using with-bindings makes it effect only single thread visible and in my mind more usable.

Second commit adds the metadata back to the f argument making it possible for the hook to operate on its name and argument, without it hooks are left only with analyzing args structure limiting its use.

Thanks
