### PR TITLE
Fix race condition hooking a var from two threads

### DIFF
--- a/src/robert/hooke.clj
+++ b/src/robert/hooke.clj
@@ -49,12 +49,14 @@
   (when-not (hooks v)
     (let [hooks (atom {})]
       (alter-var-root v (fn [original]
-                          (with-meta
-                            (fn [& args]
-                              (run-hooks (vals @hooks) original args))
-                            (assoc (meta original)
-                              ::hooks hooks
-                              ::original original)))))))
+                          (if (::hooks (meta original))
+                            original
+                            (with-meta
+                              (fn [& args]
+                                (run-hooks (vals @hooks) original args))
+                              (assoc (meta original)
+                                     ::hooks hooks
+                                     ::original original))))))))
 
 (defonce hook-scopes [])
 


### PR DESCRIPTION
It was possible for two threads to interleave their execution in such a
way that the map of hooks in the ::hooks metadata would be missing one
of the hooks.

This commit adds a second check of whether the ::hooks key has already
been added, this time inside alter-var-root's lock.